### PR TITLE
사회공헌 목록 조회, 페이징, 검색 조건 동적 쿼리 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'org.jetbrains:annotations:23.0.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/epkorea/backoffice/controller/SocialController.java
+++ b/src/main/java/com/epkorea/backoffice/controller/SocialController.java
@@ -1,0 +1,31 @@
+package com.epkorea.backoffice.controller;
+
+import com.epkorea.backoffice.dto.SocialResponseDto;
+import com.epkorea.backoffice.service.SocialService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+@RequestMapping(value="/social")
+@RequiredArgsConstructor
+public class SocialController {
+
+    private final SocialService socialService;
+
+    @GetMapping("")
+    public ModelAndView showSocialList(@RequestParam(value="currentPage", defaultValue = "1") int currentPage, ModelAndView modelAndView) {
+        SocialResponseDto socialResponseDto = socialService.getSocialList(currentPage);
+
+        modelAndView.setViewName("social_list");
+        modelAndView.addObject("socialList", socialResponseDto.getSocialList());
+        modelAndView.addObject("currentPage", socialResponseDto.getCurrentPage());
+        modelAndView.addObject("totalPages", socialResponseDto.getTotalPages());
+        modelAndView.addObject("totalElements", socialResponseDto.getTotalElements());
+
+        return modelAndView;
+    }
+}

--- a/src/main/java/com/epkorea/backoffice/controller/SocialController.java
+++ b/src/main/java/com/epkorea/backoffice/controller/SocialController.java
@@ -17,8 +17,12 @@ public class SocialController {
     private final SocialService socialService;
 
     @GetMapping("")
-    public ModelAndView showSocialList(@RequestParam(value="currentPage", defaultValue = "1") int currentPage, ModelAndView modelAndView) {
-        SocialResponseDto socialResponseDto = socialService.getSocialList(currentPage);
+    public ModelAndView showSocialList(
+            @RequestParam(value="currentPage", defaultValue = "1") int currentPage,
+            @RequestParam(value="condition", defaultValue = "") String condition,
+            @RequestParam(value="kwd", defaultValue = "") String kwd,
+            ModelAndView modelAndView) {
+        SocialResponseDto socialResponseDto = socialService.getSocialList(currentPage, condition, kwd);
 
         modelAndView.setViewName("social_list");
         modelAndView.addObject("socialList", socialResponseDto.getSocialList());

--- a/src/main/java/com/epkorea/backoffice/core/QuerydslConfig.java
+++ b/src/main/java/com/epkorea/backoffice/core/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.epkorea.backoffice.core;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/epkorea/backoffice/dto/SocialListPageDto.java
+++ b/src/main/java/com/epkorea/backoffice/dto/SocialListPageDto.java
@@ -1,0 +1,31 @@
+package com.epkorea.backoffice.dto;
+
+import com.epkorea.backoffice.repository.projection.SocialPageProjection;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SocialListPageDto {
+
+    private String title;
+    private LocalDateTime showDate;
+    private boolean isShow;
+
+    private static SocialListPageDto toDto(SocialPageProjection socialPageEntity) {
+        return SocialListPageDto.builder()
+                .title(socialPageEntity.getTitle())
+                .showDate(socialPageEntity.getShowDate())
+                .isShow(socialPageEntity.getIsShow())
+                .build();
+    }
+    public static List<SocialListPageDto> toDtoList(List<SocialPageProjection> socialPageEntityList) {
+        return socialPageEntityList.stream().map(SocialListPageDto::toDto).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/epkorea/backoffice/dto/SocialResponseDto.java
+++ b/src/main/java/com/epkorea/backoffice/dto/SocialResponseDto.java
@@ -1,0 +1,30 @@
+package com.epkorea.backoffice.dto;
+
+import com.epkorea.backoffice.repository.mapper.SocialPageMapper;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SocialResponseDto {
+
+    private List<SocialPageMapper> socialList;
+    private int currentPage;
+    private int totalPages;
+    private Long totalElements;
+
+    public static SocialResponseDto createSocialResponse(int currentPage, Page<SocialPageMapper> socialPage) {
+        final int PAGE_WEIGHT = 1;
+        return SocialResponseDto.builder()
+                .socialList(socialPage.getContent())
+                .currentPage(currentPage - PAGE_WEIGHT)
+                .totalPages(socialPage.getTotalPages())
+                .totalElements(socialPage.getTotalElements())
+                .build();
+    }
+}

--- a/src/main/java/com/epkorea/backoffice/dto/SocialResponseDto.java
+++ b/src/main/java/com/epkorea/backoffice/dto/SocialResponseDto.java
@@ -1,6 +1,6 @@
 package com.epkorea.backoffice.dto;
 
-import com.epkorea.backoffice.repository.mapper.SocialPageMapper;
+import com.epkorea.backoffice.repository.projection.SocialPageProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,18 +13,19 @@ import java.util.List;
 @AllArgsConstructor
 public class SocialResponseDto {
 
-    private List<SocialPageMapper> socialList;
+    private List<SocialListPageDto> socialList;
     private int currentPage;
     private int totalPages;
     private Long totalElements;
 
-    public static SocialResponseDto createSocialResponse(int currentPage, Page<SocialPageMapper> socialPage) {
+    public static SocialResponseDto createSocialResponse(int currentPage, Page<SocialPageProjection> socialEntityList) {
         final int PAGE_WEIGHT = 1;
+
         return SocialResponseDto.builder()
-                .socialList(socialPage.getContent())
+                .socialList(SocialListPageDto.toDtoList(socialEntityList.getContent()))
                 .currentPage(currentPage - PAGE_WEIGHT)
-                .totalPages(socialPage.getTotalPages())
-                .totalElements(socialPage.getTotalElements())
+                .totalPages(socialEntityList.getTotalPages())
+                .totalElements(socialEntityList.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/com/epkorea/backoffice/dto/SocialResponseDto.java
+++ b/src/main/java/com/epkorea/backoffice/dto/SocialResponseDto.java
@@ -1,6 +1,5 @@
 package com.epkorea.backoffice.dto;
 
-import com.epkorea.backoffice.repository.projection.SocialPageProjection;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,14 +17,12 @@ public class SocialResponseDto {
     private int totalPages;
     private Long totalElements;
 
-    public static SocialResponseDto createSocialResponse(int currentPage, Page<SocialPageProjection> socialEntityList) {
-        final int PAGE_WEIGHT = 1;
-
+    public static SocialResponseDto createSocialResponse(int currentPage, Page<SocialListPageDto> socialListPageDto) {
         return SocialResponseDto.builder()
-                .socialList(SocialListPageDto.toDtoList(socialEntityList.getContent()))
-                .currentPage(currentPage - PAGE_WEIGHT)
-                .totalPages(socialEntityList.getTotalPages())
-                .totalElements(socialEntityList.getTotalElements())
+                .socialList(socialListPageDto.getContent())
+                .currentPage(currentPage)
+                .totalPages(socialListPageDto.getTotalPages())
+                .totalElements(socialListPageDto.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/com/epkorea/backoffice/dto/UsersPageInfoDto.java
+++ b/src/main/java/com/epkorea/backoffice/dto/UsersPageInfoDto.java
@@ -1,6 +1,6 @@
 package com.epkorea.backoffice.dto;
 
-import com.epkorea.backoffice.repository.mapper.UserMapper;
+import com.epkorea.backoffice.repository.projection.UserMapper;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/epkorea/backoffice/entity/SocialContribution.java
+++ b/src/main/java/com/epkorea/backoffice/entity/SocialContribution.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "social_contributions")
@@ -19,21 +19,27 @@ public class SocialContribution {
     private Long sid;
 
     @Column(nullable = false)
+    private String title;
+
+    private String content;
+
+    @Column(nullable = false)
     private String originImagePath;
 
     @Column(nullable = false)
     private String imagePath;
 
-    private boolean isShow;
+    @Builder.Default
+    private boolean isShow = true;
 
-    @Column(name = "show_date")
-    private LocalDate showDate;
+    @Column(name = "show_date", nullable = false)
+    private LocalDateTime showDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "uid")
     private User writer;
 
-    public static SocialContribution createSocialContribution(String originImagePath, String imagePath, boolean isShow, LocalDate showDate, User writer) {
+    public static SocialContribution createSocialContribution(String originImagePath, String imagePath, boolean isShow, LocalDateTime showDate, User writer) {
         return SocialContribution.builder()
                 .originImagePath(originImagePath)
                 .imagePath(imagePath)

--- a/src/main/java/com/epkorea/backoffice/repository/SocialCustomRepository.java
+++ b/src/main/java/com/epkorea/backoffice/repository/SocialCustomRepository.java
@@ -1,0 +1,9 @@
+package com.epkorea.backoffice.repository;
+
+import com.epkorea.backoffice.dto.SocialListPageDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SocialCustomRepository {
+    Page<SocialListPageDto> findAllBySearchCondition(String condition, String kwd, Pageable pageable);
+}

--- a/src/main/java/com/epkorea/backoffice/repository/SocialCustomRepositoryImpl.java
+++ b/src/main/java/com/epkorea/backoffice/repository/SocialCustomRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.epkorea.backoffice.repository;
+
+import com.epkorea.backoffice.dto.SocialListPageDto;
+import com.epkorea.backoffice.entity.QSocialContribution;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SocialCustomRepositoryImpl implements SocialCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+    private final QSocialContribution s = QSocialContribution.socialContribution;
+
+
+    @Override
+    public Page<SocialListPageDto> findAllBySearchCondition(String condition, String kwd, Pageable pageable) {
+        List<SocialListPageDto> content =  queryFactory.select(Projections.bean(SocialListPageDto.class, s.title, s.showDate, s.isShow))
+                .from(s)
+                .where(titleContains(condition, kwd), contentContains(condition, kwd))
+                .orderBy(s.showDate.desc(), s.sid.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        int totalSize = queryFactory
+                .selectFrom(s)
+                .where(titleContains(condition, kwd), contentContains(condition, kwd))
+                .fetch().size();
+
+        return new PageImpl<>(content, pageable, totalSize);
+
+
+
+    }
+
+    private BooleanExpression titleContains(String condition, String kwd) {
+        return condition != null && condition.equals("title") ? s.title.contains(kwd) : null;
+    }
+
+    private BooleanExpression contentContains(String condition, String kwd) {
+        return condition != null && condition.equals("content") ? s.content.contains(kwd) : null;
+    }
+}

--- a/src/main/java/com/epkorea/backoffice/repository/SocialRepository.java
+++ b/src/main/java/com/epkorea/backoffice/repository/SocialRepository.java
@@ -1,0 +1,13 @@
+package com.epkorea.backoffice.repository;
+
+import com.epkorea.backoffice.entity.SocialContribution;
+import com.epkorea.backoffice.repository.mapper.SocialPageMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SocialRepository extends JpaRepository<SocialContribution, Long> {
+    Page<SocialPageMapper> findAllByOrderByShowDateDesc(Pageable pageable);
+}

--- a/src/main/java/com/epkorea/backoffice/repository/SocialRepository.java
+++ b/src/main/java/com/epkorea/backoffice/repository/SocialRepository.java
@@ -1,7 +1,7 @@
 package com.epkorea.backoffice.repository;
 
 import com.epkorea.backoffice.entity.SocialContribution;
-import com.epkorea.backoffice.repository.mapper.SocialPageMapper;
+import com.epkorea.backoffice.repository.projection.SocialPageProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,5 +9,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SocialRepository extends JpaRepository<SocialContribution, Long> {
-    Page<SocialPageMapper> findAllByOrderByShowDateDesc(Pageable pageable);
+    Page<SocialPageProjection> findAllByOrderByShowDateDesc(Pageable pageable);
 }

--- a/src/main/java/com/epkorea/backoffice/repository/SocialRepository.java
+++ b/src/main/java/com/epkorea/backoffice/repository/SocialRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SocialRepository extends JpaRepository<SocialContribution, Long> {
+public interface SocialRepository extends JpaRepository<SocialContribution, Long>, SocialCustomRepository {
     Page<SocialPageProjection> findAllByOrderByShowDateDesc(Pageable pageable);
 }

--- a/src/main/java/com/epkorea/backoffice/repository/UserRepository.java
+++ b/src/main/java/com/epkorea/backoffice/repository/UserRepository.java
@@ -1,7 +1,7 @@
 package com.epkorea.backoffice.repository;
 
 import com.epkorea.backoffice.entity.User;
-import com.epkorea.backoffice.repository.mapper.UserMapper;
+import com.epkorea.backoffice.repository.projection.UserMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/epkorea/backoffice/repository/mapper/SocialPageMapper.java
+++ b/src/main/java/com/epkorea/backoffice/repository/mapper/SocialPageMapper.java
@@ -1,0 +1,10 @@
+package com.epkorea.backoffice.repository.mapper;
+
+import java.time.LocalDateTime;
+
+public interface SocialPageMapper {
+
+    String getTitle();
+    LocalDateTime getShowDate();
+    boolean getIsShow();
+}

--- a/src/main/java/com/epkorea/backoffice/repository/projection/SocialPageProjection.java
+++ b/src/main/java/com/epkorea/backoffice/repository/projection/SocialPageProjection.java
@@ -1,8 +1,8 @@
-package com.epkorea.backoffice.repository.mapper;
+package com.epkorea.backoffice.repository.projection;
 
 import java.time.LocalDateTime;
 
-public interface SocialPageMapper {
+public interface SocialPageProjection {
 
     String getTitle();
     LocalDateTime getShowDate();

--- a/src/main/java/com/epkorea/backoffice/repository/projection/UserMapper.java
+++ b/src/main/java/com/epkorea/backoffice/repository/projection/UserMapper.java
@@ -1,4 +1,4 @@
-package com.epkorea.backoffice.repository.mapper;
+package com.epkorea.backoffice.repository.projection;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/epkorea/backoffice/service/SocialService.java
+++ b/src/main/java/com/epkorea/backoffice/service/SocialService.java
@@ -1,8 +1,8 @@
 package com.epkorea.backoffice.service;
 
+import com.epkorea.backoffice.dto.SocialListPageDto;
 import com.epkorea.backoffice.dto.SocialResponseDto;
 import com.epkorea.backoffice.repository.SocialRepository;
-import com.epkorea.backoffice.repository.projection.SocialPageProjection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -15,11 +15,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class SocialService {
     private final SocialRepository socialRepository;
 
-    public SocialResponseDto getSocialList(int currentPage) {
+    public SocialResponseDto getSocialList(int currentPage, String condition, String kwd) {
         int PAGE_WEIGHT = 1;
         int PAGE_LENGTH = 10;
-        Page<SocialPageProjection> socialPageEntity = socialRepository.findAllByOrderByShowDateDesc(PageRequest.of(currentPage - PAGE_WEIGHT, PAGE_LENGTH));
+        Page<SocialListPageDto> socialListPageDto = socialRepository.findAllBySearchCondition(condition, kwd, PageRequest.of(currentPage - PAGE_WEIGHT, PAGE_LENGTH));
 
-        return SocialResponseDto.createSocialResponse(currentPage, socialPageEntity);
+        return SocialResponseDto.createSocialResponse(currentPage - PAGE_WEIGHT, socialListPageDto);
     }
 }

--- a/src/main/java/com/epkorea/backoffice/service/SocialService.java
+++ b/src/main/java/com/epkorea/backoffice/service/SocialService.java
@@ -2,7 +2,7 @@ package com.epkorea.backoffice.service;
 
 import com.epkorea.backoffice.dto.SocialResponseDto;
 import com.epkorea.backoffice.repository.SocialRepository;
-import com.epkorea.backoffice.repository.mapper.SocialPageMapper;
+import com.epkorea.backoffice.repository.projection.SocialPageProjection;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,8 +18,8 @@ public class SocialService {
     public SocialResponseDto getSocialList(int currentPage) {
         int PAGE_WEIGHT = 1;
         int PAGE_LENGTH = 10;
-        Page<SocialPageMapper> socialPage = socialRepository.findAllByOrderByShowDateDesc(PageRequest.of(currentPage - PAGE_WEIGHT, PAGE_LENGTH));
+        Page<SocialPageProjection> socialPageEntity = socialRepository.findAllByOrderByShowDateDesc(PageRequest.of(currentPage - PAGE_WEIGHT, PAGE_LENGTH));
 
-        return SocialResponseDto.createSocialResponse(currentPage, socialPage);
+        return SocialResponseDto.createSocialResponse(currentPage, socialPageEntity);
     }
 }

--- a/src/main/java/com/epkorea/backoffice/service/SocialService.java
+++ b/src/main/java/com/epkorea/backoffice/service/SocialService.java
@@ -1,0 +1,25 @@
+package com.epkorea.backoffice.service;
+
+import com.epkorea.backoffice.dto.SocialResponseDto;
+import com.epkorea.backoffice.repository.SocialRepository;
+import com.epkorea.backoffice.repository.mapper.SocialPageMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SocialService {
+    private final SocialRepository socialRepository;
+
+    public SocialResponseDto getSocialList(int currentPage) {
+        int PAGE_WEIGHT = 1;
+        int PAGE_LENGTH = 10;
+        Page<SocialPageMapper> socialPage = socialRepository.findAllByOrderByShowDateDesc(PageRequest.of(currentPage - PAGE_WEIGHT, PAGE_LENGTH));
+
+        return SocialResponseDto.createSocialResponse(currentPage, socialPage);
+    }
+}

--- a/src/main/java/com/epkorea/backoffice/service/UserLogService.java
+++ b/src/main/java/com/epkorea/backoffice/service/UserLogService.java
@@ -15,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserLogService {
     private static final int PAGE_LENGTH = 10;
     private static final int PAGE_WEIGHT = 1;  // URL currentPage 파라매터 직관성을 위한 가중치
-
     @Autowired
     UserLoggingRepository userLoggingRepository;
 

--- a/src/main/java/com/epkorea/backoffice/service/UserService.java
+++ b/src/main/java/com/epkorea/backoffice/service/UserService.java
@@ -6,7 +6,7 @@ import com.epkorea.backoffice.dto.UsersPageInfoDto;
 import com.epkorea.backoffice.entity.Authority;
 import com.epkorea.backoffice.entity.User;
 import com.epkorea.backoffice.repository.UserRepository;
-import com.epkorea.backoffice.repository.mapper.UserMapper;
+import com.epkorea.backoffice.repository.projection.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;


### PR DESCRIPTION
1. 사회공헌의 글 목록을 Select 하여 전달할 수 있는 로직을 추가합니다.
    - 데이터 조회에 필요한 Controller, Service, Repository 구성합니다.
2. 기존 Projection을 사용해서 JPARepository의 특정 컬럼만 조회할 수 있도록 했습니다. 하지만 반환값이 DTO가 아닌 Entity 또는 Tuple 타입이라는 생각에 Repository --> Service 계층 전달 시 DTO로 변환하여 전달하는 로직을 추가했습니다.
3. 사회공헌 검색 조건인 제목/내용을 기존의 각각의 메소드로 구현했던 방식과 다르게 querydsl을 사용하여 where절의 동적쿼리를 생성하도록 구현하였습니다. 
